### PR TITLE
Add cart checkout payment and email features

### DIFF
--- a/shop/src/main/java/com/example/shop/controller/CartController.java
+++ b/shop/src/main/java/com/example/shop/controller/CartController.java
@@ -1,0 +1,41 @@
+package com.example.shop.controller;
+
+import com.example.shop.dto.CartItemRequest;
+import com.example.shop.dto.CartItemUpdateRequest;
+import com.example.shop.dto.CartViewDTO;
+import com.example.shop.service.CartService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/cart")
+@RequiredArgsConstructor
+public class CartController {
+    private final CartService cartService;
+
+    @PostMapping("/items")
+    public CartViewDTO addItem(@RequestHeader("X-USER-ID") Long userId,
+                               @RequestBody @Valid CartItemRequest request) {
+        return cartService.addItem(userId, request.getProductId(), request.getQuantity());
+    }
+
+    @PutMapping("/items/{itemId}")
+    public CartViewDTO updateItem(@RequestHeader("X-USER-ID") Long userId,
+                                  @PathVariable Long itemId,
+                                  @RequestBody @Valid CartItemUpdateRequest request) {
+        return cartService.updateItem(userId, itemId, request.getQuantity());
+    }
+
+    @DeleteMapping("/items/{itemId}")
+    public CartViewDTO deleteItem(@RequestHeader("X-USER-ID") Long userId,
+                                  @PathVariable Long itemId) {
+        return cartService.removeItem(userId, itemId);
+    }
+
+    @GetMapping
+    public CartViewDTO getCart(@RequestHeader("X-USER-ID") Long userId) {
+        return cartService.getCart(userId);
+    }
+}
+

--- a/shop/src/main/java/com/example/shop/controller/OrderController.java
+++ b/shop/src/main/java/com/example/shop/controller/OrderController.java
@@ -1,0 +1,28 @@
+package com.example.shop.controller;
+
+import com.example.shop.dto.CheckoutRequestDTO;
+import com.example.shop.dto.OrderDTO;
+import com.example.shop.service.CheckoutService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/orders")
+@RequiredArgsConstructor
+public class OrderController {
+    private final CheckoutService checkoutService;
+
+    @PostMapping("/checkout")
+    public OrderDTO checkout(@RequestHeader("X-USER-ID") Long userId,
+                             @RequestBody @Valid CheckoutRequestDTO request) {
+        return checkoutService.checkoutCOD(userId, request);
+    }
+
+    @GetMapping("/{id}")
+    public OrderDTO getOrder(@RequestHeader("X-USER-ID") Long userId,
+                             @PathVariable Long id) {
+        return checkoutService.getOrder(userId, id);
+    }
+}
+

--- a/shop/src/main/java/com/example/shop/controller/PaymentController.java
+++ b/shop/src/main/java/com/example/shop/controller/PaymentController.java
@@ -1,0 +1,57 @@
+package com.example.shop.controller;
+
+import com.example.shop.dto.PaymentCreateRequest;
+import com.example.shop.entity.Order;
+import com.example.shop.entity.Payment;
+import com.example.shop.repository.OrderRepository;
+import com.example.shop.repository.PaymentRepository;
+import com.example.shop.service.MailService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+    private final PaymentRepository paymentRepository;
+    private final OrderRepository orderRepository;
+    private final MailService mailService;
+
+    @PostMapping("/create")
+    public Map<String, String> create(@RequestBody @Valid PaymentCreateRequest request) {
+        Order order = orderRepository.findById(request.getOrderId())
+                .orElseThrow(() -> new IllegalArgumentException("Order not found"));
+        Payment payment = paymentRepository.findByOrderId(order.getId()).orElse(new Payment());
+        payment.setOrder(order);
+        payment.setAmount(order.getTotal());
+        payment.setMethod(request.getMethod());
+        payment.setStatus("PENDING");
+        paymentRepository.save(payment);
+        Map<String, String> res = new HashMap<>();
+        res.put("callbackUrl", "/payments/callback?orderId=" + order.getId() + "&status=success");
+        return res;
+    }
+
+    @GetMapping("/callback")
+    public Map<String, String> callback(@RequestParam Long orderId, @RequestParam String status) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("Order not found"));
+        Payment payment = paymentRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("Payment not found"));
+        if ("success".equalsIgnoreCase(status)) {
+            payment.setStatus("SUCCESS");
+            paymentRepository.save(payment);
+            order.setStatus("PAID");
+            orderRepository.save(order);
+            mailService.sendOrderPaid(order);
+        }
+        Map<String, String> res = new HashMap<>();
+        res.put("status", "ok");
+        return res;
+    }
+}
+

--- a/shop/src/main/java/com/example/shop/dto/CartItemRequest.java
+++ b/shop/src/main/java/com/example/shop/dto/CartItemRequest.java
@@ -1,0 +1,15 @@
+package com.example.shop.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class CartItemRequest {
+    @NotNull
+    private Long productId;
+
+    @Min(1)
+    private int quantity;
+}
+

--- a/shop/src/main/java/com/example/shop/dto/CartItemUpdateRequest.java
+++ b/shop/src/main/java/com/example/shop/dto/CartItemUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.example.shop.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.Data;
+
+@Data
+public class CartItemUpdateRequest {
+    @Min(1)
+    private int quantity;
+}
+

--- a/shop/src/main/java/com/example/shop/dto/CartItemView.java
+++ b/shop/src/main/java/com/example/shop/dto/CartItemView.java
@@ -1,0 +1,19 @@
+package com.example.shop.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CartItemView {
+    private Long itemId;
+    private Long productId;
+    private String name;
+    private BigDecimal price;
+    private int quantity;
+}
+

--- a/shop/src/main/java/com/example/shop/dto/CartViewDTO.java
+++ b/shop/src/main/java/com/example/shop/dto/CartViewDTO.java
@@ -1,0 +1,18 @@
+package com.example.shop.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CartViewDTO {
+    private List<CartItemView> items;
+    private BigDecimal subtotal;
+    private BigDecimal total;
+}
+

--- a/shop/src/main/java/com/example/shop/dto/CheckoutRequestDTO.java
+++ b/shop/src/main/java/com/example/shop/dto/CheckoutRequestDTO.java
@@ -1,0 +1,15 @@
+package com.example.shop.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class CheckoutRequestDTO {
+    @NotBlank
+    private String fullName;
+    @NotBlank
+    private String phone;
+    @NotBlank
+    private String address;
+}
+

--- a/shop/src/main/java/com/example/shop/dto/OrderDTO.java
+++ b/shop/src/main/java/com/example/shop/dto/OrderDTO.java
@@ -1,0 +1,21 @@
+package com.example.shop.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderDTO {
+    private Long id;
+    private BigDecimal total;
+    private String status;
+    private Instant createdAt;
+    private List<OrderItemView> items;
+}
+

--- a/shop/src/main/java/com/example/shop/dto/OrderItemView.java
+++ b/shop/src/main/java/com/example/shop/dto/OrderItemView.java
@@ -1,0 +1,18 @@
+package com.example.shop.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderItemView {
+    private Long productId;
+    private String name;
+    private BigDecimal price;
+    private int quantity;
+}
+

--- a/shop/src/main/java/com/example/shop/dto/PaymentCreateRequest.java
+++ b/shop/src/main/java/com/example/shop/dto/PaymentCreateRequest.java
@@ -1,0 +1,14 @@
+package com.example.shop.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class PaymentCreateRequest {
+    @NotNull
+    private Long orderId;
+    @NotBlank
+    private String method;
+}
+

--- a/shop/src/main/java/com/example/shop/entity/Cart.java
+++ b/shop/src/main/java/com/example/shop/entity/Cart.java
@@ -1,0 +1,28 @@
+package com.example.shop.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "carts")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Cart {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", unique = true)
+    private User user;
+
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CartItem> items = new ArrayList<>();
+}
+

--- a/shop/src/main/java/com/example/shop/entity/CartItem.java
+++ b/shop/src/main/java/com/example/shop/entity/CartItem.java
@@ -1,0 +1,29 @@
+package com.example.shop.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "cart_items")
+@Getter
+@Setter
+@NoArgsConstructor
+public class CartItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id")
+    private Cart cart;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Column(nullable = false)
+    private int quantity;
+}
+

--- a/shop/src/main/java/com/example/shop/entity/Order.java
+++ b/shop/src/main/java/com/example/shop/entity/Order.java
@@ -1,0 +1,39 @@
+package com.example.shop.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "orders")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Order {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private BigDecimal total;
+
+    @Column(name = "status")
+    private String status;
+
+    @Column(name = "created_at", insertable = false, updatable = false)
+    private Instant createdAt;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> items = new ArrayList<>();
+}
+

--- a/shop/src/main/java/com/example/shop/entity/OrderItem.java
+++ b/shop/src/main/java/com/example/shop/entity/OrderItem.java
@@ -1,0 +1,34 @@
+package com.example.shop.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "order_items")
+@Getter
+@Setter
+@NoArgsConstructor
+public class OrderItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(nullable = false)
+    private BigDecimal price;
+}
+

--- a/shop/src/main/java/com/example/shop/entity/Payment.java
+++ b/shop/src/main/java/com/example/shop/entity/Payment.java
@@ -1,0 +1,31 @@
+package com.example.shop.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "payments")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Payment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    private String method;
+
+    private String status;
+}
+

--- a/shop/src/main/java/com/example/shop/repository/CartItemRepository.java
+++ b/shop/src/main/java/com/example/shop/repository/CartItemRepository.java
@@ -1,0 +1,11 @@
+package com.example.shop.repository;
+
+import com.example.shop.entity.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+    Optional<CartItem> findByCartIdAndProductId(Long cartId, Long productId);
+}
+

--- a/shop/src/main/java/com/example/shop/repository/CartRepository.java
+++ b/shop/src/main/java/com/example/shop/repository/CartRepository.java
@@ -1,0 +1,11 @@
+package com.example.shop.repository;
+
+import com.example.shop.entity.Cart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+    Optional<Cart> findByUserId(Long userId);
+}
+

--- a/shop/src/main/java/com/example/shop/repository/OrderItemRepository.java
+++ b/shop/src/main/java/com/example/shop/repository/OrderItemRepository.java
@@ -1,0 +1,8 @@
+package com.example.shop.repository;
+
+import com.example.shop.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+}
+

--- a/shop/src/main/java/com/example/shop/repository/OrderRepository.java
+++ b/shop/src/main/java/com/example/shop/repository/OrderRepository.java
@@ -1,0 +1,11 @@
+package com.example.shop.repository;
+
+import com.example.shop.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    Optional<Order> findByIdAndUserId(Long id, Long userId);
+}
+

--- a/shop/src/main/java/com/example/shop/repository/PaymentRepository.java
+++ b/shop/src/main/java/com/example/shop/repository/PaymentRepository.java
@@ -1,0 +1,11 @@
+package com.example.shop.repository;
+
+import com.example.shop.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    Optional<Payment> findByOrderId(Long orderId);
+}
+

--- a/shop/src/main/java/com/example/shop/service/CartService.java
+++ b/shop/src/main/java/com/example/shop/service/CartService.java
@@ -1,0 +1,112 @@
+package com.example.shop.service;
+
+import com.example.shop.dto.CartItemView;
+import com.example.shop.dto.CartViewDTO;
+import com.example.shop.entity.Cart;
+import com.example.shop.entity.CartItem;
+import com.example.shop.entity.Product;
+import com.example.shop.entity.User;
+import com.example.shop.repository.CartItemRepository;
+import com.example.shop.repository.CartRepository;
+import com.example.shop.repository.ProductRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public CartViewDTO addItem(Long userId, Long productId, int quantity) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("Product not found"));
+        if (product.getStock() < quantity) {
+            throw new IllegalArgumentException("Not enough stock");
+        }
+        Cart cart = cartRepository.findByUserId(userId).orElseGet(() -> {
+            Cart c = new Cart();
+            User user = new User();
+            user.setId(userId);
+            c.setUser(user);
+            return cartRepository.save(c);
+        });
+        CartItem item = cartItemRepository.findByCartIdAndProductId(cart.getId(), productId).orElse(null);
+        if (item == null) {
+            item = new CartItem();
+            item.setCart(cart);
+            item.setProduct(product);
+            item.setQuantity(quantity);
+        } else {
+            int newQty = item.getQuantity() + quantity;
+            if (product.getStock() < newQty) {
+                throw new IllegalArgumentException("Not enough stock");
+            }
+            item.setQuantity(newQty);
+        }
+        cartItemRepository.save(item);
+        cart = cartRepository.findById(cart.getId()).orElseThrow();
+        return toView(cart);
+    }
+
+    @Transactional
+    public CartViewDTO updateItem(Long userId, Long itemId, int quantity) {
+        Cart cart = cartRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("Cart not found"));
+        CartItem item = cartItemRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("Item not found"));
+        if (!item.getCart().getId().equals(cart.getId())) {
+            throw new IllegalArgumentException("Item not in cart");
+        }
+        Product product = item.getProduct();
+        if (product.getStock() < quantity) {
+            throw new IllegalArgumentException("Not enough stock");
+        }
+        item.setQuantity(quantity);
+        cartItemRepository.save(item);
+        cart = cartRepository.findById(cart.getId()).orElseThrow();
+        return toView(cart);
+    }
+
+    @Transactional
+    public CartViewDTO removeItem(Long userId, Long itemId) {
+        Cart cart = cartRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("Cart not found"));
+        CartItem item = cartItemRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("Item not found"));
+        if (!item.getCart().getId().equals(cart.getId())) {
+            throw new IllegalArgumentException("Item not in cart");
+        }
+        cartItemRepository.delete(item);
+        cart = cartRepository.findById(cart.getId()).orElseThrow();
+        return toView(cart);
+    }
+
+    @Transactional
+    public CartViewDTO getCart(Long userId) {
+        Cart cart = cartRepository.findByUserId(userId).orElse(null);
+        if (cart == null) {
+            return new CartViewDTO(new ArrayList<>(), BigDecimal.ZERO, BigDecimal.ZERO);
+        }
+        return toView(cart);
+    }
+
+    private CartViewDTO toView(Cart cart) {
+        List<CartItemView> items = cart.getItems().stream()
+                .map(ci -> new CartItemView(ci.getId(), ci.getProduct().getId(), ci.getProduct().getName(), ci.getProduct().getPrice(), ci.getQuantity()))
+                .collect(Collectors.toList());
+        BigDecimal subtotal = items.stream()
+                .map(i -> i.getPrice().multiply(BigDecimal.valueOf(i.getQuantity())))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        return new CartViewDTO(items, subtotal, subtotal);
+    }
+}
+

--- a/shop/src/main/java/com/example/shop/service/CheckoutService.java
+++ b/shop/src/main/java/com/example/shop/service/CheckoutService.java
@@ -1,0 +1,78 @@
+package com.example.shop.service;
+
+import com.example.shop.dto.CheckoutRequestDTO;
+import com.example.shop.dto.OrderDTO;
+import com.example.shop.dto.OrderItemView;
+import com.example.shop.entity.*;
+import com.example.shop.repository.*;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CheckoutService {
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final ProductRepository productRepository;
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final MailService mailService;
+
+    @Transactional
+    public OrderDTO checkoutCOD(Long userId, CheckoutRequestDTO request) {
+        Cart cart = cartRepository.findByUserId(userId)
+                .orElseThrow(() -> new IllegalArgumentException("Cart not found"));
+        if (cart.getItems().isEmpty()) {
+            throw new IllegalArgumentException("Cart is empty");
+        }
+        BigDecimal total = BigDecimal.ZERO;
+        for (CartItem item : cart.getItems()) {
+            Product product = item.getProduct();
+            if (product.getStock() < item.getQuantity()) {
+                throw new IllegalArgumentException("Not enough stock for product " + product.getId());
+            }
+            BigDecimal line = product.getPrice().multiply(BigDecimal.valueOf(item.getQuantity()));
+            total = total.add(line);
+        }
+        Order order = new Order();
+        order.setUser(cart.getUser());
+        order.setTotal(total);
+        order.setStatus("CONFIRMED");
+        order = orderRepository.save(order);
+        for (CartItem item : cart.getItems()) {
+            Product product = item.getProduct();
+            product.setStock(product.getStock() - item.getQuantity());
+            productRepository.save(product);
+            OrderItem oi = new OrderItem();
+            oi.setOrder(order);
+            oi.setProduct(product);
+            oi.setQuantity(item.getQuantity());
+            oi.setPrice(product.getPrice());
+            orderItemRepository.save(oi);
+        }
+        cartItemRepository.deleteAll(cart.getItems());
+        mailService.sendOrderConfirmed(order);
+        order = orderRepository.findById(order.getId()).orElseThrow();
+        return toDTO(order);
+    }
+
+    @Transactional
+    public OrderDTO getOrder(Long userId, Long id) {
+        Order order = orderRepository.findByIdAndUserId(id, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Order not found"));
+        return toDTO(order);
+    }
+
+    private OrderDTO toDTO(Order order) {
+        List<OrderItemView> items = order.getItems().stream()
+                .map(oi -> new OrderItemView(oi.getProduct().getId(), oi.getProduct().getName(), oi.getPrice(), oi.getQuantity()))
+                .collect(Collectors.toList());
+        return new OrderDTO(order.getId(), order.getTotal(), order.getStatus(), order.getCreatedAt(), items);
+    }
+}
+

--- a/shop/src/main/java/com/example/shop/service/MailService.java
+++ b/shop/src/main/java/com/example/shop/service/MailService.java
@@ -1,0 +1,18 @@
+package com.example.shop.service;
+
+import com.example.shop.entity.Order;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class MailService {
+    public void sendOrderConfirmed(Order order) {
+        log.info("[MAIL] Order {} confirmed", order.getId());
+    }
+
+    public void sendOrderPaid(Order order) {
+        log.info("[MAIL] Order {} paid", order.getId());
+    }
+}
+

--- a/shop/src/main/resources/db/migration/V3__add_order_status.sql
+++ b/shop/src/main/resources/db/migration/V3__add_order_status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders ADD COLUMN status VARCHAR(50);


### PR DESCRIPTION
## Summary
- implement cart service and API for adding, updating, removing items
- implement checkout to create orders and deduct stock
- add payment mock with callback updating order status and sending email

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68961a3c118c8324aa54dcf5c29fb381