### PR TITLE
Add PasswordEncoder bean

### DIFF
--- a/shop/src/main/java/com/example/shop/config/SecurityConfig.java
+++ b/shop/src/main/java/com/example/shop/config/SecurityConfig.java
@@ -3,6 +3,8 @@ package com.example.shop.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -12,5 +14,10 @@ public class SecurityConfig {
         http.csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }


### PR DESCRIPTION
## Summary
- add BCryptPasswordEncoder PasswordEncoder bean to security configuration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68961dc611688324b90bd0d9dfd1fde4