### PR TITLE
feat: add shop frontend

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,3 @@
+const nextConfig = {};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "3.3.3",
+    "postcss": "8.4.31",
+    "autoprefixer": "10.4.16",
+    "@radix-ui/react-toast": "^1.1.5",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^1.2.1",
+    "tailwind-merge": "^1.14.0",
+    "lucide-react": "^0.298.0"
+  },
+  "devDependencies": {
+    "typescript": "5.2.2",
+    "eslint": "8.48.0",
+    "eslint-config-next": "14.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/app/cart/page.tsx
+++ b/frontend/src/app/cart/page.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import CartItemRow from "@/components/CartItemRow";
+import { useToast } from "@/components/ui/use-toast";
+
+export default function CartPage() {
+  const { toast } = useToast();
+  const [items, setItems] = useState<any[]>([]);
+
+  const load = async () => {
+    try {
+      const data = await api.get("/cart");
+      setItems(data.items || data);
+    } catch (err: any) {
+      toast({ title: "Error", description: err.message, variant: "destructive" });
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const subtotal = items.reduce(
+    (sum, i) => sum + i.product.price * i.quantity,
+    0
+  );
+
+  return (
+    <div className="space-y-4">
+      {items.map((item) => (
+        <CartItemRow key={item.id} item={item} onChanged={load} />
+      ))}
+      <div className="text-right space-y-1">
+        <div>Subtotal: ${subtotal.toFixed(2)}</div>
+        <div>Total: ${subtotal.toFixed(2)}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/checkout/page.tsx
+++ b/frontend/src/app/checkout/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/lib/api";
+import { useToast } from "@/components/ui/use-toast";
+
+export default function CheckoutPage() {
+  const { toast } = useToast();
+  const [form, setForm] = useState({ fullName: "", phone: "", address: "" });
+
+  const submit = async () => {
+    try {
+      await api.post("/orders/checkout", form);
+    } catch (err: any) {
+      toast({ title: "Error", description: err.message, variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="max-w-md space-y-4">
+      <input
+        className="w-full border p-2"
+        placeholder="Full Name"
+        value={form.fullName}
+        onChange={(e) => setForm({ ...form, fullName: e.target.value })}
+      />
+      <input
+        className="w-full border p-2"
+        placeholder="Phone"
+        value={form.phone}
+        onChange={(e) => setForm({ ...form, phone: e.target.value })}
+      />
+      <textarea
+        className="w-full border p-2"
+        placeholder="Address"
+        value={form.address}
+        onChange={(e) => setForm({ ...form, address: e.target.value })}
+      />
+      <button className="px-4 py-2 bg-blue-600 text-white" onClick={submit}>
+        Checkout
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import "./globals.css";
+import { Toaster } from "@/components/ui/toaster";
+import { ToastProvider } from "@/components/ui/use-toast";
+
+export const metadata: Metadata = {
+  title: "Shop",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-white">
+        <ToastProvider>
+          <nav className="flex items-center justify-between p-4 border-b">
+            <Link href="/" className="font-bold text-xl">
+              Shop
+            </Link>
+            <div className="space-x-4">
+              <Link href="/cart">Cart</Link>
+              <Link href="/login">Login</Link>
+            </div>
+          </nav>
+          <main className="p-4">{children}</main>
+          <Toaster />
+        </ToastProvider>
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import ProductCard from "@/components/ProductCard";
+import { useToast } from "@/components/ui/use-toast";
+
+export default function HomePage() {
+  const { toast } = useToast();
+  const [keyword, setKeyword] = useState("");
+  const [products, setProducts] = useState<any[]>([]);
+  const [page, setPage] = useState(0);
+
+  useEffect(() => {
+    fetchProducts();
+  }, [page]);
+
+  const fetchProducts = async () => {
+    try {
+      const data = await api.get(
+        `/products?keyword=${encodeURIComponent(keyword)}&page=${page}&size=12`
+      );
+      setProducts(data.items || data);
+    } catch (err: any) {
+      toast({ title: "Error", description: err.message, variant: "destructive" });
+    }
+  };
+
+  const onSearch = () => {
+    setPage(0);
+    fetchProducts();
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-2">
+        <input
+          className="border p-2 flex-1"
+          placeholder="Search products"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+        />
+        <button className="px-4 py-2 bg-blue-600 text-white" onClick={onSearch}>
+          Search
+        </button>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {products.map((p) => (
+          <ProductCard key={p.id} product={p} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/product/[id]/page.tsx
+++ b/frontend/src/app/product/[id]/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { api } from "@/lib/api";
+import { useToast } from "@/components/ui/use-toast";
+
+export default function ProductDetail({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const { toast } = useToast();
+  const [product, setProduct] = useState<any>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await api.get(`/products/${params.id}`);
+        setProduct(data);
+      } catch (err: any) {
+        toast({ title: "Error", description: err.message, variant: "destructive" });
+      }
+    };
+    load();
+  }, [params.id]);
+
+  const addToCart = async () => {
+    try {
+      await api.post(`/cart`, { productId: params.id, quantity: 1 });
+    } catch (err: any) {
+      toast({ title: "Error", description: err.message, variant: "destructive" });
+    }
+  };
+
+  if (!product) return <div>Loading...</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">{product.name}</h1>
+      <p>{product.description}</p>
+      <p className="font-semibold">${product.price}</p>
+      <button className="px-4 py-2 bg-green-600 text-white" onClick={addToCart}>
+        Add to Cart
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/CartItemRow.tsx
+++ b/frontend/src/components/CartItemRow.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { api } from "@/lib/api";
+import { useToast } from "@/components/ui/use-toast";
+
+export default function CartItemRow({
+  item,
+  onChanged,
+}: {
+  item: any;
+  onChanged: () => void;
+}) {
+  const { toast } = useToast();
+
+  const updateQty = async (qty: number) => {
+    try {
+      await api.put(`/cart/${item.id}`, { quantity: qty });
+      onChanged();
+    } catch (err: any) {
+      toast({ title: "Error", description: err.message, variant: "destructive" });
+    }
+  };
+
+  const remove = async () => {
+    try {
+      await api.delete(`/cart/${item.id}`);
+      onChanged();
+    } catch (err: any) {
+      toast({ title: "Error", description: err.message, variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between border-b py-2">
+      <div>
+        <div className="font-semibold">{item.product.name}</div>
+        <div>${item.product.price}</div>
+      </div>
+      <div className="flex items-center space-x-2">
+        <input
+          type="number"
+          min={1}
+          value={item.quantity}
+          onChange={(e) => updateQty(parseInt(e.target.value))}
+          className="w-16 border p-1"
+        />
+        <button className="text-red-600" onClick={remove}>
+          Remove
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ProductCard.tsx
+++ b/frontend/src/components/ProductCard.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export default function ProductCard({
+  product,
+}: {
+  product: any;
+}) {
+  return (
+    <Link
+      href={`/product/${product.id}`}
+      className="border p-4 rounded block space-y-2"
+    >
+      <div className="font-semibold">{product.name}</div>
+      <div>${product.price}</div>
+    </Link>
+  );
+}

--- a/frontend/src/components/ui/toaster.tsx
+++ b/frontend/src/components/ui/toaster.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import * as ToastPrimitive from "@radix-ui/react-toast";
+import { useToast } from "./use-toast";
+import { cn } from "@/lib/utils";
+
+export function Toaster() {
+  const { toasts, dismiss } = useToast();
+  return (
+    <ToastPrimitive.Provider>
+      {toasts.map((t) => (
+        <ToastPrimitive.Root
+          key={t.id}
+          open
+          onOpenChange={(o) => !o && dismiss(t.id)}
+          className={cn(
+            "bg-white border rounded p-4 shadow flex justify-between items-start space-x-4",
+            t.variant === "destructive" && "bg-red-600 text-white"
+          )}
+        >
+          <div className="grid gap-1">
+            <ToastPrimitive.Title className="font-semibold">
+              {t.title}
+            </ToastPrimitive.Title>
+            {t.description && (
+              <ToastPrimitive.Description>{t.description}</ToastPrimitive.Description>
+            )}
+          </div>
+          <ToastPrimitive.Close className="text-sm">✕</ToastPrimitive.Close>
+        </ToastPrimitive.Root>
+      ))}
+      <ToastPrimitive.Viewport className="fixed top-0 right-0 p-4 flex flex-col gap-2 w-full max-w-sm z-[100]" />
+    </ToastPrimitive.Provider>
+  );
+}

--- a/frontend/src/components/ui/use-toast.tsx
+++ b/frontend/src/components/ui/use-toast.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { createContext, useContext, useState } from "react";
+
+export type Toast = {
+  id: number;
+  title: string;
+  description?: string;
+  variant?: "default" | "destructive";
+};
+
+type ToastCtx = {
+  toasts: Toast[];
+  toast: (t: Omit<Toast, "id">) => void;
+  dismiss: (id: number) => void;
+};
+
+const ToastContext = createContext<ToastCtx | undefined>(undefined);
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const toast = (t: Omit<Toast, "id">) => {
+    setToasts((prev) => [...prev, { id: Date.now(), ...t }]);
+  };
+
+  const dismiss = (id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  };
+
+  return (
+    <ToastContext.Provider value={{ toasts, toast, dismiss }}>
+      {children}
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
+  return ctx;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,33 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
+
+async function request(path: string, options: RequestInit = {}) {
+  const res = await fetch(`${API_URL}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      "X-USER-ID": "demo",
+      ...(options.headers || {}),
+    },
+    ...options,
+  });
+
+  if (!res.ok) {
+    let message = "Request failed";
+    try {
+      const data = await res.json();
+      message = data.message || JSON.stringify(data);
+    } catch {}
+    throw new Error(message);
+  }
+
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+export const api = {
+  get: (url: string) => request(url),
+  post: (url: string, body: any) =>
+    request(url, { method: "POST", body: JSON.stringify(body) }),
+  put: (url: string, body: any) =>
+    request(url, { method: "PUT", body: JSON.stringify(body) }),
+  delete: (url: string) => request(url, { method: "DELETE" }),
+};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: any[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: [
+    "./src/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+export default config

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add Next.js 14 frontend with tailwind and shadcn toast
- implement product listing, details, cart, and checkout pages
- provide API client with default demo user header

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68961d7a4de483249f8345c0776a61d8