### PR TITLE
Seed demo data and enhance security config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # ShopTamDV
+
+## Backend
+
+```bash
+cd shop
+mvn clean package
+mvn spring-boot:run
+```
+
+Swagger: <http://localhost:8080/swagger-ui.html>
+
+H2 console: <http://localhost:8080/h2-console> (jdbc:h2:mem:testdb)
+
+## Frontend
+
+```bash
+cd frontend
+cp .env.local.example .env.local
+npm install
+npm run dev
+```
+
+App: <http://localhost:3000>

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_API_URL=http://localhost:8080
+NEXT_PUBLIC_USER_ID=demo

--- a/shop/src/main/java/com/example/shop/DataSeeder.java
+++ b/shop/src/main/java/com/example/shop/DataSeeder.java
@@ -1,0 +1,60 @@
+package com.example.shop;
+
+import com.example.shop.entity.Category;
+import com.example.shop.entity.Product;
+import com.example.shop.repository.CategoryRepository;
+import com.example.shop.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DataSeeder implements CommandLineRunner {
+
+    private final CategoryRepository categoryRepository;
+    private final ProductRepository productRepository;
+
+    @Override
+    public void run(String... args) {
+        if (categoryRepository.count() > 0 || productRepository.count() > 0) {
+            return;
+        }
+        Category c1 = new Category();
+        c1.setName("Books");
+        c1.setSlug("books");
+        Category c2 = new Category();
+        c2.setName("Electronics");
+        c2.setSlug("electronics");
+        Category c3 = new Category();
+        c3.setName("Clothes");
+        c3.setSlug("clothes");
+        categoryRepository.saveAll(List.of(c1, c2, c3));
+
+        productRepository.saveAll(List.of(
+            createProduct("Book A", "book-a", BigDecimal.valueOf(10), 100, c1),
+            createProduct("Book B", "book-b", BigDecimal.valueOf(12), 80, c1),
+            createProduct("Phone", "phone", BigDecimal.valueOf(500), 50, c2),
+            createProduct("Laptop", "laptop", BigDecimal.valueOf(1000), 30, c2),
+            createProduct("Shirt", "shirt", BigDecimal.valueOf(20), 200, c3),
+            createProduct("Jeans", "jeans", BigDecimal.valueOf(40), 150, c3)
+        ));
+
+        log.info("Seeded demo data");
+    }
+
+    private Product createProduct(String name, String slug, BigDecimal price, int stock, Category category) {
+        Product p = new Product();
+        p.setName(name);
+        p.setSlug(slug);
+        p.setPrice(price);
+        p.setStock(stock);
+        p.setCategory(category);
+        return p;
+    }
+}

--- a/shop/src/main/java/com/example/shop/config/SecurityConfig.java
+++ b/shop/src/main/java/com/example/shop/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.shop.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -14,6 +15,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -21,7 +23,11 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.List;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, AuthenticationProvider authenticationProvider) throws Exception {
         http
@@ -37,7 +43,8 @@ public class SecurityConfig {
                 .requestMatchers("/cart/**", "/orders/checkout").permitAll()
                 .requestMatchers("/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated()
-            );
+            )
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/shop/src/main/resources/application.yml
+++ b/shop/src/main/resources/application.yml
@@ -26,7 +26,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health,info
   endpoint:
     health:
       show-details: always


### PR DESCRIPTION
## Summary
- expose actuator info endpoint
- add JWT filter configuration
- seed demo categories and products
- add frontend env example and usage docs

## Testing
- `mvn -q clean package` *(fails: Network is unreachable)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896328e34a88324941118a73a2a3c0e