### PR TITLE
fix(frontend): normalize product list responses

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,17 +1,26 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { api } from "@/lib/api";
+import { api, apiList } from "@/lib/api";
 import ProductCard from "@/components/ProductCard";
 
+interface Product {
+  id: string;
+  name: string;
+  price: number;
+  image?: string;
+}
+
 export default function HomePage() {
-  const [products, setProducts] = useState<any[]>([]);
+  const [products, setProducts] = useState<Product[]>([]);
 
   useEffect(() => {
     const load = async () => {
       try {
-        const data = await api("/products?page=0&size=12&sort=id");
-        setProducts(data.items || data);
+        const data = await apiList<Product>(
+          `/products?page=0&size=12&sort=id`
+        );
+        setProducts(data);
       } catch (err: any) {
         alert(err.message);
       }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -16,3 +16,10 @@ export async function api(path: string, init: RequestInit = {}) {
   if (res.status === 204) return null;
   return res.json();
 }
+
+export async function apiList<T>(path: string): Promise<T[]> {
+  const data = await api(path);
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data?.content)) return data.content;
+  return [];
+}


### PR DESCRIPTION
## Summary
- add `apiList` helper to safely parse list responses
- fetch products with `apiList` to avoid non-array runtime error

## Testing
- `npm test`
- `npm run lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/undici-types)*

------
https://chatgpt.com/codex/tasks/task_e_689635f4c36883248dde877b051a35f0