### PR TITLE
Implement JWT authentication and admin seeding

### DIFF
--- a/shop/src/main/java/com/example/shop/DataSeeder.java
+++ b/shop/src/main/java/com/example/shop/DataSeeder.java
@@ -2,15 +2,21 @@ package com.example.shop;
 
 import com.example.shop.entity.Category;
 import com.example.shop.entity.Product;
+import com.example.shop.entity.Role;
+import com.example.shop.entity.User;
 import com.example.shop.repository.CategoryRepository;
 import com.example.shop.repository.ProductRepository;
+import com.example.shop.repository.RoleRepository;
+import com.example.shop.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -19,9 +25,13 @@ public class DataSeeder implements CommandLineRunner {
 
     private final CategoryRepository categoryRepository;
     private final ProductRepository productRepository;
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public void run(String... args) {
+        seedAdmin();
         if (categoryRepository.count() > 0 || productRepository.count() > 0) {
             return;
         }
@@ -46,6 +56,19 @@ public class DataSeeder implements CommandLineRunner {
         ));
 
         log.info("Seeded demo data");
+    }
+
+    private void seedAdmin() {
+        if (userRepository.existsByUsername("admin")) {
+            return;
+        }
+        Role role = roleRepository.findByName("ROLE_ADMIN")
+                .orElseGet(() -> roleRepository.save(new Role(null, "ROLE_ADMIN")));
+        User user = new User();
+        user.setUsername("admin");
+        user.setPassword(passwordEncoder.encode("admin"));
+        user.setRoles(Set.of(role));
+        userRepository.save(user);
     }
 
     private Product createProduct(String name, String slug, BigDecimal price, int stock, Category category) {

--- a/shop/src/main/java/com/example/shop/config/JwtAuthenticationFilter.java
+++ b/shop/src/main/java/com/example/shop/config/JwtAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
             UserDetails userDetails = userService.loadUserByUsername(username);
-            if (jwtService.isTokenValid(token, userDetails)) {
+            if (jwtService.validate(token)) {
                 UsernamePasswordAuthenticationToken authToken =
                         new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));

--- a/shop/src/main/java/com/example/shop/controller/AuthController.java
+++ b/shop/src/main/java/com/example/shop/controller/AuthController.java
@@ -20,9 +20,8 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signup")
-    public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequest request) {
-        authService.signup(request);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<AuthResponse> signup(@Valid @RequestBody SignupRequest request) {
+        return ResponseEntity.ok(authService.signup(request));
     }
 
     @PostMapping("/login")

--- a/shop/src/main/resources/application.yml
+++ b/shop/src/main/resources/application.yml
@@ -30,3 +30,6 @@ management:
   endpoint:
     health:
       show-details: always
+
+jwt:
+  secret: YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4


### PR DESCRIPTION
## Summary
- return tokens on signup and login and support refresh
- add JWT service with configurable secret and validation
- seed default admin account on startup

## Testing
- `./mvnw clean package` *(fails: Failed to fetch apache-maven-3.9.11-bin.zip)*
- `./mvnw spring-boot:run` *(fails: Failed to fetch apache-maven-3.9.11-bin.zip)*
- `mvn clean package` *(fails: Network is unreachable while resolving parent POM)*
- `mvn spring-boot:run` *(fails: Network is unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6896387a9598832484ff47dc63273dbb