### PR TITLE
feat: add basic auth pages and helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ```bash
 cd shop
-mvn clean package
-mvn spring-boot:run
+./mvnw clean package
+./mvnw spring-boot:run
 ```
 
 Swagger: <http://localhost:8080/swagger-ui.html>
@@ -20,5 +20,7 @@ cp .env.local.example .env.local
 npm install
 npm run dev
 ```
+
+Required env variables are provided in `.env.local.example`.
 
 App: <http://localhost:3000>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -17,13 +17,19 @@ export default function RootLayout({
     <html lang="en">
       <body className="min-h-screen bg-white">
         <ToastProvider>
-          <nav className="flex items-center justify-between p-4 border-b">
+          <nav className="flex items-center p-4 border-b gap-4">
             <Link href="/" className="font-bold text-xl">
               Shop
             </Link>
-            <div className="space-x-4">
+            <input
+              type="text"
+              placeholder="Search..."
+              className="flex-1 border p-2"
+            />
+            <div className="space-x-4 whitespace-nowrap">
               <Link href="/cart">Cart</Link>
               <Link href="/login">Login</Link>
+              <Link href="/register">Register</Link>
             </div>
           </nav>
           <main className="p-4">{children}</main>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { login } from "@/lib/auth";
+import { useToast } from "@/components/ui/use-toast";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await login(email, password);
+      toast({ title: "Logged in" });
+      router.push("/");
+    } catch (err: any) {
+      toast({ title: "Login failed", description: err.message, variant: "destructive" });
+    }
+  };
+
+  return (
+    <form className="max-w-sm space-y-4" onSubmit={submit}>
+      <input
+        type="email"
+        className="w-full border p-2"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <input
+        type="password"
+        className="w-full border p-2"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white w-full">
+        Login
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { signup } from "@/lib/auth";
+import { useToast } from "@/components/ui/use-toast";
+
+export default function RegisterPage() {
+  const [form, setForm] = useState({ fullName: "", email: "", password: "" });
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await signup(form);
+      toast({ title: "Registered" });
+      router.push("/");
+    } catch (err: any) {
+      toast({ title: "Register failed", description: err.message, variant: "destructive" });
+    }
+  };
+
+  return (
+    <form className="max-w-sm space-y-4" onSubmit={submit}>
+      <input
+        className="w-full border p-2"
+        placeholder="Full Name"
+        value={form.fullName}
+        onChange={(e) => setForm({ ...form, fullName: e.target.value })}
+        required
+      />
+      <input
+        type="email"
+        className="w-full border p-2"
+        placeholder="Email"
+        value={form.email}
+        onChange={(e) => setForm({ ...form, email: e.target.value })}
+        required
+      />
+      <input
+        type="password"
+        className="w-full border p-2"
+        placeholder="Password"
+        value={form.password}
+        onChange={(e) => setForm({ ...form, password: e.target.value })}
+        required
+      />
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white w-full">
+        Register
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,0 +1,47 @@
+import { api } from "./api";
+
+const TOKEN_KEY = "accessToken";
+
+export function getToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(TOKEN_KEY, token);
+  document.cookie = `${TOKEN_KEY}=${token}; path=/`;
+}
+
+export function clearToken() {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(TOKEN_KEY);
+  document.cookie = `${TOKEN_KEY}=; Max-Age=0; path=/`;
+}
+
+export async function login(email: string, password: string) {
+  const data = await api("/auth/login", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  if (data?.accessToken) setToken(data.accessToken);
+  return data;
+}
+
+export async function signup(payload: {
+  fullName: string;
+  email: string;
+  password: string;
+}) {
+  const data = await api("/auth/signup", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  if (data?.accessToken) setToken(data.accessToken);
+  return data;
+}
+
+export function authHeader(): Record<string, string> {
+  const token = getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}


### PR DESCRIPTION
## Summary
- add auth utility for login and signup token storage
- create login and register pages using toast notifications
- enhance layout with search bar and register link
- document backend/frontend run commands

## Testing
- `cd shop && ./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68963feedd388324b649d7274214e9b6